### PR TITLE
Screens restructuring

### DIFF
--- a/client/include/client.h
+++ b/client/include/client.h
@@ -1,9 +1,7 @@
 #ifndef WAR_OF_AGES_CLIENT_H
 #define WAR_OF_AGES_CLIENT_H
 
-#include <SFML/Graphics.hpp>
-#include <TGUI/Backend/SFML-Graphics.hpp>
-#include <TGUI/TGUI.hpp>
+#include <TGUI/Backend/SFML-Graphics.hpp>  // tgui::Gui, tgui::String
 #include <memory>
 #include "../../game_logic/include/game_state.h"
 #include "screen_defines.h"

--- a/client/include/end_game_screen.h
+++ b/client/include/end_game_screen.h
@@ -1,7 +1,7 @@
 #ifndef WAR_OF_AGES_END_GAME_SCREEN_H
 #define WAR_OF_AGES_END_GAME_SCREEN_H
 
-#include <TGUI/Backend/SFML-Graphics.hpp>
+#include <TGUI/Backend/SFML-Graphics.hpp>  // tgui::Gui
 
 namespace war_of_ages {
 void end_game_screen_init(tgui::Gui &gui);

--- a/client/include/game_screen.h
+++ b/client/include/game_screen.h
@@ -1,7 +1,7 @@
 #ifndef WAR_OF_AGES_GAME_SCREEN_H
 #define WAR_OF_AGES_GAME_SCREEN_H
 
-#include <TGUI/Backend/SFML-Graphics.hpp>
+#include <TGUI/Backend/SFML-Graphics.hpp>  // tgui::Gui
 
 namespace war_of_ages {
 void game_screen_init(tgui::Gui &gui);

--- a/client/include/multiplayer_screen.h
+++ b/client/include/multiplayer_screen.h
@@ -1,9 +1,7 @@
 #ifndef WAR_OF_AGES_MULTIPLAYER_SCREEN_H
 #define WAR_OF_AGES_MULTIPLAYER_SCREEN_H
 
-#include <SFML/Graphics.hpp>
-#include <TGUI/Backend/SFML-Graphics.hpp>
-#include <TGUI/TGUI.hpp>
+#include <TGUI/Backend/SFML-Graphics.hpp>  // tgui::Gui
 
 namespace war_of_ages {
 void multiplayer_screen_init(tgui::Gui &gui);

--- a/client/include/pause_screen.h
+++ b/client/include/pause_screen.h
@@ -1,9 +1,7 @@
 #ifndef WAR_OF_AGES_PAUSE_SCREEN_H
 #define WAR_OF_AGES_PAUSE_SCREEN_H
 
-#include <SFML/Graphics.hpp>
-#include <TGUI/Backend/SFML-Graphics.hpp>
-#include <TGUI/TGUI.hpp>
+#include <TGUI/Backend/SFML-Graphics.hpp>  // tgui::Gui
 
 namespace war_of_ages {
 void pause_screen_init(tgui::Gui &gui);

--- a/client/include/screens.h
+++ b/client/include/screens.h
@@ -1,19 +1,15 @@
 #ifndef WAR_OF_AGES_SCREENS_H
 #define WAR_OF_AGES_SCREENS_H
 
+#include <TGUI/Backend/SFML-Graphics.hpp>  // tgui::Gui
 #include "client.h"
-#include "game_screen.h"
-#include "multiplayer_screen.h"
-#include "pause_screen.h"
-#include "settings_screen.h"
-#include "start_screen.h"
-#include "tournament_screens.h"
-#include "wait_screen.h"
 
 namespace war_of_ages {
 
+void screens_init(tgui::Gui &gui);
+
 void update_screens(tgui::Gui &gui, const client_state &state, sf::RenderWindow *window);
 
-}
+}  // namespace war_of_ages
 
 #endif  // WAR_OF_AGES_SCREENS_H

--- a/client/include/settings_screen.h
+++ b/client/include/settings_screen.h
@@ -1,9 +1,7 @@
 #ifndef WAR_OF_AGES_SETTINGS_SCREEN_H
 #define WAR_OF_AGES_SETTINGS_SCREEN_H
 
-#include <SFML/Graphics.hpp>
-#include <TGUI/Backend/SFML-Graphics.hpp>
-#include <TGUI/TGUI.hpp>
+#include <TGUI/Backend/SFML-Graphics.hpp>  // tgui::Gui
 
 namespace war_of_ages {
 void settings_screen_init(tgui::Gui &gui);

--- a/client/include/start_screen.h
+++ b/client/include/start_screen.h
@@ -1,9 +1,7 @@
 #ifndef WAR_OF_AGES_START_SCREEN_H
 #define WAR_OF_AGES_START_SCREEN_H
 
-#include <SFML/Graphics.hpp>
-#include <TGUI/Backend/SFML-Graphics.hpp>
-#include <TGUI/TGUI.hpp>
+#include <TGUI/Backend/SFML-Graphics.hpp>  // tgui::Gui
 
 namespace war_of_ages {
 void start_screen_init(tgui::Gui &gui);

--- a/client/include/tournament.h
+++ b/client/include/tournament.h
@@ -1,10 +1,11 @@
 #ifndef WAR_OF_AGES_TOURNAMENT_H
 #define WAR_OF_AGES_TOURNAMENT_H
 
-#include <SFML/Graphics.hpp>
-#include <TGUI/Backend/SFML-Graphics.hpp>
-#include <TGUI/TGUI.hpp>
+#include <TGUI/Backend/SFML-Graphics.hpp>  // tgui::Gui, tgui::String
+#include <TGUI/Widgets/Grid.hpp>           // tgui::Grid
+#include <map>
 #include <mutex>
+#include <vector>
 
 namespace war_of_ages {
 

--- a/client/include/tournament_screens.h
+++ b/client/include/tournament_screens.h
@@ -1,10 +1,7 @@
 #ifndef WAR_OF_AGES_TOURNAMENT_SCREENS_H
 #define WAR_OF_AGES_TOURNAMENT_SCREENS_H
 
-#include <SFML/Graphics.hpp>
-#include <TGUI/Backend/SFML-Graphics.hpp>
-#include <TGUI/TGUI.hpp>
-#include <mutex>
+#include <TGUI/Backend/SFML-Graphics.hpp>  // tgui::Gui
 
 namespace war_of_ages {
 

--- a/client/include/wait_screen.h
+++ b/client/include/wait_screen.h
@@ -1,8 +1,7 @@
 #ifndef WAR_OF_AGES_WAIT_SCREEN_H
 #define WAR_OF_AGES_WAIT_SCREEN_H
 
-#include <TGUI/Backend/SFML-Graphics.hpp>
-#include <TGUI/TGUI.hpp>
+#include <TGUI/Backend/SFML-Graphics.hpp>  // tgui::Gui
 
 namespace war_of_ages {
 

--- a/client/src/main.cpp
+++ b/client/src/main.cpp
@@ -1,44 +1,12 @@
-#include <SFML/Graphics.hpp>
 #include <TGUI/Backend/SFML-Graphics.hpp>
 #include <chrono>
 #include "../include/client.h"
-#include "../include/end_game_screen.h"
 #include "../include/game_object_size_constants.h"
-#include "../include/screen_defines.h"
 #include "../include/screens.h"
 #include "../include/sprite_printer.h"
 #include "../include/ui_functions.h"
 
 namespace war_of_ages {
-
-void screens_init(tgui::Gui &gui) {
-    // Widgets of every screen are defined here
-
-    // Ilya's screens
-
-    tournament_screen_init(gui);
-    tournament_creation_screen_init(gui);
-    tournament_join_screen_init(gui);
-
-    // end Ilya's screens
-
-    // Vakhtang's screens
-
-    start_screen_init(gui);
-    multiplayer_screen_init(gui);
-    settings_screen_init(gui);
-
-    // end Vakhtang's screens
-
-    // Timur's screens
-
-    opponent_waiting_screen_init(gui);
-    game_screen_init(gui);
-    end_game_screen_init(gui);
-    pause_screen_init(gui);
-
-    // end Timur's screens
-}
 
 war_of_ages::client_state current_state;
 

--- a/client/src/screens.cpp
+++ b/client/src/screens.cpp
@@ -1,11 +1,48 @@
 #include "../include/screens.h"
-#include "../include/client.h"
-#include "../include/game_object_size_constants.h"
-#include "../include/screen_defines.h"
+#include <TGUI/Widgets/Group.hpp>
+
+// Screen headers
+
+#include "../include/end_game_screen.h"
+#include "../include/game_screen.h"
+#include "../include/multiplayer_screen.h"
+#include "../include/pause_screen.h"
+#include "../include/settings_screen.h"
 #include "../include/sprite_printer.h"
-#include "../include/sprite_supplier.h"
+#include "../include/start_screen.h"
+#include "../include/tournament_screens.h"
+#include "../include/wait_screen.h"
 
 namespace war_of_ages {
+
+void screens_init(tgui::Gui &gui) {
+    // Widgets of every screen are defined here
+
+    // Ilya's screens
+
+    tournament_screen_init(gui);
+    tournament_creation_screen_init(gui);
+    tournament_join_screen_init(gui);
+
+    // end Ilya's screens
+
+    // Vakhtang's screens
+
+    start_screen_init(gui);
+    multiplayer_screen_init(gui);
+    settings_screen_init(gui);
+
+    // end Vakhtang's screens
+
+    // Timur's screens
+
+    opponent_waiting_screen_init(gui);
+    game_screen_init(gui);
+    end_game_screen_init(gui);
+    pause_screen_init(gui);
+
+    // end Timur's screens
+}
 
 void update_screens(tgui::Gui &gui, const client_state &state, sf::RenderWindow *window) {
     switch (state.get_cur_screen()) {


### PR DESCRIPTION
Немного прорефакторил код, ответственный за отображение окон.

- Повыкидывал лишние инклуды
- Добавил недостающие инклуды
- Заменил некоторые инклуды более конкретными и, как следствие, более лёгкими
- Перенёс функцию `screens_init()` из `main.cpp` в `screens.cpp`